### PR TITLE
Use context.request.body for logging request body

### DIFF
--- a/src/Middleware/HindsightRequestLogger.php
+++ b/src/Middleware/HindsightRequestLogger.php
@@ -35,9 +35,11 @@ class HindsightRequestLogger
             'headers' => $this->filterHeaders($request->headers->all()),
         ]);
 
-        Log::debug('Request initiated', array_merge(array_filter([
-            'data' => $request->except(config('hindsight.blacklist.fields', [])),
-        ]), ['code' => 'hindsight.request-started']));
+        Log::debug('Request initiated', array_merge([
+            'request' => array_filter([
+                'body' => $request->except(config('hindsight.blacklist.fields', [])),
+            ])
+        ], ['code' => 'hindsight.request-started']));
 
         /** @var \Illuminate\Http\Response $response */
         $response = $next($request);


### PR DESCRIPTION
As per discussion on internal Slack, this moves the request body logging to `context.request.body` instead of `context.data` so that I can make the field in Elasticsearch unindexed (stored and returned, but not searchable) to avoid mapping conflicts.